### PR TITLE
Add support for <M-BS> as delete-backward-word

### DIFF
--- a/doc/rsi.txt
+++ b/doc/rsi.txt
@@ -46,6 +46,9 @@ MAPS                                            *rsi-maps*
                                                 *rsi-META-d*
 <M-d>                   Delete forwards one word.
 
+                                                *rsi-META-BS*
+<M-BS>                  Delete backward one word.
+
                                                 *rsi-META-f*
 <M-f>                   Go forwards one word.
 

--- a/plugin/rsi.vim
+++ b/plugin/rsi.vim
@@ -35,6 +35,7 @@ cmap   <script> <C-T> <SID>transposition<SID>transpose
 
 noremap!        <M-b> <S-Left>
 noremap!        <M-d> <C-O>dw
+noremap!        <M-BS> <C-W>
 noremap!        <M-f> <S-Right>
 noremap!        <M-n> <Down>
 noremap!        <M-p> <Up>
@@ -45,9 +46,13 @@ if !has("gui_running")
   silent! exe "set <F31>=\<Esc>d"
   silent! exe "set <F32>=\<Esc>n"
   silent! exe "set <F33>=\<Esc>p"
+  silent! exe "set <F34>=\<Esc>\<C-?>"
+  silent! exe "set <F35>=\<Esc>\<C-H>"
   map! <F31> <M-d>
   map! <F32> <M-n>
   map! <F33> <M-p>
+  map! <F34> <M-BS>
+  map! <F35> <M-BS>
 endif
 
 " vim:set et sw=2:


### PR DESCRIPTION
Although `<C-W>` is perfectly useful already, one of the readline key bindings I use a lot is `<M-BS>` ("delete-backward-word").  However, implementing this is complicated by the fact that it is apparently impossible(?) to get the actual backspace key within vim.  Attempts to, for example,

```
    exe "set <F34>=\<Esc>\<BS>"
```

result in `<F34>` being set to `<Esc><80>fb`, which is probably some internal indirect reference to the termcap variable, and, moreover, doesn't work. Inexplicably, as well, one cannot retrieve the value of &t_xx (&t_fb specifically is what we want here) termcap options in vim script.

As far as I know, in the modern era, terminals generally use either `<C-H>` or `<C-?>` for backspace; and sometimes these are transposed with the bindings for `<Del>`. My brutish solution is to bind both `<Esc><C-H>` and `<Esc><C-?>` to the desired function. The consequence is that, for some terminals, `<M-Del>` might be bound to the same as `<M-BS>`, but I don't think `<M-Del>` means anything in readline anyhow.
