### PR TITLE
Command-line CTRL-U,  CTRL-Y

### DIFF
--- a/plugin/rsi.vim
+++ b/plugin/rsi.vim
@@ -47,6 +47,16 @@ endfunction
 
 cnoremap <expr> <C-T> <SID>transpose()
 
+function! s:ctrl_u()
+  if getcmdpos() > 1
+    let @- = getcmdline()[:getcmdpos()-2]
+  endif
+  return "\<C-U>"
+endfunction
+
+cnoremap <expr> <C-U> <SID>ctrl_u()
+cnoremap        <C-Y> <C-R>-
+
 if exists('g:rsi_no_meta')
   finish
 endif


### PR DESCRIPTION
ref https://github.com/tpope/vim-rsi/pull/1

- CTRL-U in cmdline-mode stores in the `@-` register
- CTRL-Y in cmdline-mode yanks from the `@-` register