### PR TITLE
Add support for disabling meta mappings

### DIFF
--- a/doc/rsi.txt
+++ b/doc/rsi.txt
@@ -67,6 +67,10 @@ for a second if you actually press just escape.  Instead, rsi.vim makes
 these available by telling Vim they are existing special keys. For example,
 the key code for <S-Left> is changed to <Esc>b.
 
+To disable meta maps, add the following to your vimrc:
+>
+    let g:rsi_no_meta = 1
+<
 ABOUT                                           *rsi-about*
 
 Grab the latest version or report a bug on GitHub:

--- a/plugin/rsi.vim
+++ b/plugin/rsi.vim
@@ -37,6 +37,10 @@ noremap! <expr> <SID>transposition getcmdpos()>strlen(getcmdline())?"\<Left>":ge
 noremap! <expr> <SID>transpose "\<BS>\<Right>".matchstr(getcmdline()[0 : getcmdpos()-2], '.$')
 cmap   <script> <C-T> <SID>transposition<SID>transpose
 
+if exists('g:rsi_no_meta')
+  finish
+endif
+
 if &encoding ==# 'latin1' && has('gui_running') && !empty(findfile('plugin/sensible.vim', escape(&rtp, ' ')))
   set encoding=utf-8
 endif


### PR DESCRIPTION
This adds support for g:rsi_no_meta. I wasn't sure whether:
- to check for g:rsi_no_meta before or after `set encoding=utf-8` (I decided to check before this is set)
- to document this setting in doc/rsi.txt (decided to document it)

Let me know if the PR can be improved.

Refs #14, #5
