### PR TITLE
Options for disabling meta maps in insert and/or command mode

### DIFF
--- a/doc/rsi.txt
+++ b/doc/rsi.txt
@@ -71,6 +71,11 @@ To disable meta maps, add the following to your vimrc:
 >
     let g:rsi_no_meta = 1
 <
+You can also disable meta maps for insert or command mode only :
+>
+    let g:rsi_no_insert_meta = 1
+    let g:rsi_no_cmd_meta = 1
+<
 ABOUT                                           *rsi-about*
 
 Grab the latest version or report a bug on GitHub:

--- a/plugin/rsi.vim
+++ b/plugin/rsi.vim
@@ -47,7 +47,7 @@ endfunction
 
 cnoremap <expr> <C-T> <SID>transpose()
 
-if exists('g:rsi_no_meta')
+if exists('g:rsi_no_meta') && g:rsi_no_meta == 1
   finish
 endif
 
@@ -55,13 +55,25 @@ if &encoding ==# 'latin1' && has('gui_running') && !empty(findfile('plugin/sensi
   set encoding=utf-8
 endif
 
-noremap!        <M-b> <S-Left>
-noremap!        <M-d> <C-O>dw
-cnoremap        <M-d> <S-Right><C-W>
-noremap!        <M-BS> <C-W>
-noremap!        <M-f> <S-Right>
-noremap!        <M-n> <Down>
-noremap!        <M-p> <Up>
+"insert mode meta maps
+if !exists('g:rsi_no_insert_meta') || g:rsi_no_insert_meta == 0
+  inoremap        <M-b> <S-Left>
+  inoremap        <M-d> <C-O>dw
+  inoremap        <M-BS> <C-W>
+  inoremap        <M-f> <S-Right>
+  inoremap        <M-n> <Down>
+  inoremap        <M-p> <Up>
+endif
+
+"cmd mode meta maps
+if !exists('g:rsi_no_cmd_meta') || g:rsi_no_cmd_meta == 0
+  cnoremap        <M-b> <S-Left>
+  cnoremap        <M-d> <S-Right><C-W>
+  cnoremap        <M-BS> <C-W>
+  cnoremap        <M-f> <S-Right>
+  cnoremap        <M-n> <Down>
+  cnoremap        <M-p> <Up>
+endif
 
 if !has("gui_running") && !has('nvim')
   silent! exe "set <S-Left>=\<Esc>b"


### PR DESCRIPTION
At first, I've noticed that I couldn't insert `î` character and then, I've noticed that people had put issues about some other characters that couldn't be inserted such as `ä`. The thing is that I like this plugin only for the meta maps inside the **command** mode so I can edit my command faster. That's why I've implemented some options to disable _insert_ mode meta maps. I thought that adding the option for disabling _command_ mode meta maps wasn't that hard either, so I put it in. People don't really put special UTF-8 characters inside a command so the option for disabling the command mode meta maps may be irrelevant. That's why I've seperated the implementation of both in seperate commits so all of the modifications could be cherry-picked.

I hope those changes can be appreciated and merged !

Cheers !
