### PR TITLE
add ctrl-k mapping.

### DIFF
--- a/plugin/rsi.vim
+++ b/plugin/rsi.vim
@@ -24,6 +24,13 @@ cnoremap        <C-B> <Left>
 inoremap <expr> <C-D> col('.')>strlen(getline('.'))?"\<Lt>C-D>":"\<Lt>Del>"
 cnoremap <expr> <C-D> getcmdpos()>strlen(getcmdline())?"\<Lt>C-D>":"\<Lt>Del>"
 
+if empty(mapcheck('<C-k>', 'i'))
+  inoremap <C-k> <C-o>C
+endif
+if empty(mapcheck('<C-k>', 'c'))
+  cnoremap <C-k> <C-\>estrpart(getcmdline(), 0, getcmdpos()-1)<CR>
+endif
+
 inoremap <expr> <C-E> col('.')>strlen(getline('.'))<bar><bar>pumvisible()?"\<Lt>C-E>":"\<Lt>End>"
 
 inoremap <expr> <C-F> col('.')>strlen(getline('.'))?"\<Lt>C-F>":"\<Lt>Right>"


### PR DESCRIPTION
closes #27.

C-k is only remapped if no previous mapping existed, to avoid creating conflicts for those who have bound C-k to something else (I believe by default vim doesn't bind C-k to anything).