### PR TITLE
Prevent <C-b> and <C-f> from breaking undo sequence in insert mode

### DIFF
--- a/plugin/rsi.vim
+++ b/plugin/rsi.vim
@@ -13,9 +13,12 @@ if &ttimeoutlen == -1
   set ttimeoutlen=50
 endif
 
-let g:keep_undo_sequence = v:version > 704 || v:version == 704 && has("patch849") ? 1 : 0
+let s:ctrlg_u = has('patch-7.4.849') ? "\u07\u55" : ""
+function! s:CtrlGU()
+  return s:ctrlg_u
+endfunction
 
-inoremap <expr> <C-A> empty(g:keep_undo_sequence)
+inoremap <expr> <C-A> empty(<SID>CtrlGU())
 \ ? "\<Lt>C-O>^"
 \ : col('.') >= match(getline('.'), '\S') + 1
 \   ? repeat('<C-G>U<Left>', col('.') - match(getline('.'), '\S') - 1)
@@ -26,9 +29,9 @@ cnoremap   <C-X><C-A> <C-A>
 
 inoremap <expr> <C-B> getline('.')=~'^\s*$'&&col('.')>strlen(getline('.'))
 \ ? "0\<Lt>C-D>\<Lt>Esc>kJs"
-\ : g:keep_undo_sequence
-\   ? "\<Lt>C-G>U\<Lt>Left>"
-\   : "\<Lt>Left>"
+\ : empty(<SID>CtrlGU())
+\   ? "\<Lt>Left>"
+\   : <SID>CtrlGU() . "\<Lt>Left>"
 cnoremap        <C-B> <Left>
 
 inoremap <expr> <C-D> col('.')>strlen(getline('.'))?"\<Lt>C-D>":"\<Lt>Del>"
@@ -36,15 +39,15 @@ cnoremap <expr> <C-D> getcmdpos()>strlen(getcmdline())?"\<Lt>C-D>":"\<Lt>Del>"
 
 inoremap <expr> <C-E> col('.')>strlen(getline('.'))<bar><bar>pumvisible()
 \ ? "\<Lt>C-E>"
-\ : empty(g:keep_undo_sequence)
+\ : empty(<SID>CtrlGU())
 \   ? "\<Lt>End>"
-\   : repeat('<C-G>U<Right>', strlen(getline('.')) - col('.') + 1)
+\   : repeat('<C-G>U<Right>', col('$') - col('.'))
 
 inoremap <expr> <C-F> col('.')>strlen(getline('.'))
 \ ? "\<Lt>C-F>"
-\ : g:keep_undo_sequence
-\   ? "\<Lt>C-G>U\<Lt>Right>"
-\   : "\<Lt>Right>"
+\ : empty(<SID>CtrlGU())
+\   ? "\<Lt>Right>"
+\   : "\<Lt>C-G>U\<Lt>Right>"
 cnoremap <expr> <C-F> getcmdpos()>strlen(getcmdline())?&cedit:"\<Lt>Right>"
 
 if empty(mapcheck('<C-G>', 'c'))

--- a/plugin/rsi.vim
+++ b/plugin/rsi.vim
@@ -18,7 +18,7 @@ inoremap   <C-X><C-A> <C-A>
 cnoremap        <C-A> <Home>
 cnoremap   <C-X><C-A> <C-A>
 
-inoremap <expr> <C-B> getline('.')=~'^\s*$'&&col('.')>strlen(getline('.'))?"0\<Lt>C-D>\<Lt>Esc>kJs":"\<Lt>Left>"
+inoremap <expr> <C-B> getline('.')=~'^\s*$'&&col('.')>strlen(getline('.'))?"0\<Lt>C-D>\<Lt>Esc>kJs":"\<Lt>C-g>U\<Lt>Left>"
 cnoremap        <C-B> <Left>
 
 inoremap <expr> <C-D> col('.')>strlen(getline('.'))?"\<Lt>C-D>":"\<Lt>Del>"
@@ -26,7 +26,7 @@ cnoremap <expr> <C-D> getcmdpos()>strlen(getcmdline())?"\<Lt>C-D>":"\<Lt>Del>"
 
 inoremap <expr> <C-E> col('.')>strlen(getline('.'))<bar><bar>pumvisible()?"\<Lt>C-E>":"\<Lt>End>"
 
-inoremap <expr> <C-F> col('.')>strlen(getline('.'))?"\<Lt>C-F>":"\<Lt>Right>"
+inoremap <expr> <C-F> col('.')>strlen(getline('.'))?"\<Lt>C-F>":"\<Lt>C-g>U\<Lt>Right>"
 cnoremap <expr> <C-F> getcmdpos()>strlen(getcmdline())?&cedit:"\<Lt>Right>"
 
 if empty(mapcheck('<C-G>', 'c'))

--- a/plugin/rsi.vim
+++ b/plugin/rsi.vim
@@ -62,13 +62,20 @@ if &encoding ==# 'latin1' && has('gui_running') && !empty(findfile('plugin/sensi
   set encoding=utf-8
 endif
 
-noremap!        <M-b> <S-Left>
+cnoremap        <M-b> <S-Left>
 noremap!        <M-d> <C-O>dw
 cnoremap        <M-d> <S-Right><C-W>
 noremap!        <M-BS> <C-W>
-noremap!        <M-f> <S-Right>
+cnoremap        <M-f> <S-Right>
 noremap!        <M-n> <Down>
 noremap!        <M-p> <Up>
+
+inoremap <expr> <S-Left> col('.') <= match(getline('.'), '\S') + 1 <bar><bar> empty(<SID>CtrlGU()) 
+ \ ? '<S-Left>'
+ \ : repeat('<C-G>U<Left>', col('.') - match(getline('.'), '\v\s\zs\w+\s?%' . col('.') . 'c') - 1)
+inoremap <expr> <S-Right> col('.') > match(getline('.'), '\s\w', col('.')-1)+1 <bar><bar> empty(<SID>CtrlGU())
+ \ ? '<S-Right>'
+ \ : repeat('<C-G>U<Right>', match(getline('.'), '\s\w', col('.')-1) - col('.') + 2)
 
 if !has("gui_running")
   silent! exe "set <S-Left>=\<Esc>b"

--- a/plugin/rsi.vim
+++ b/plugin/rsi.vim
@@ -29,9 +29,7 @@ cnoremap   <C-X><C-A> <C-A>
 
 inoremap <expr> <C-B> getline('.')=~'^\s*$'&&col('.')>strlen(getline('.'))
 \ ? "0\<Lt>C-D>\<Lt>Esc>kJs"
-\ : empty(<SID>CtrlGU())
-\   ? "\<Lt>Left>"
-\   : <SID>CtrlGU() . "\<Lt>Left>"
+\ : <SID>CtrlGU() . "\<Lt>Left>"
 cnoremap        <C-B> <Left>
 
 inoremap <expr> <C-D> col('.')>strlen(getline('.'))?"\<Lt>C-D>":"\<Lt>Del>"
@@ -45,9 +43,7 @@ inoremap <expr> <C-E> col('.')>strlen(getline('.'))<bar><bar>pumvisible()
 
 inoremap <expr> <C-F> col('.')>strlen(getline('.'))
 \ ? "\<Lt>C-F>"
-\ : empty(<SID>CtrlGU())
-\   ? "\<Lt>Right>"
-\   : "\<Lt>C-G>U\<Lt>Right>"
+\ : <SID>CtrlGU() . "\<Lt>Right>"
 cnoremap <expr> <C-F> getcmdpos()>strlen(getcmdline())?&cedit:"\<Lt>Right>"
 
 if empty(mapcheck('<C-G>', 'c'))

--- a/plugin/rsi.vim
+++ b/plugin/rsi.vim
@@ -70,12 +70,12 @@ cnoremap        <M-f> <S-Right>
 noremap!        <M-n> <Down>
 noremap!        <M-p> <Up>
 
-inoremap <expr> <S-Left> col('.') <= match(getline('.'), '\S') + 1 <bar><bar> empty(<SID>CtrlGU()) 
+inoremap <expr> <S-Left> col('.') <= match(getline('.'), '\S') + 2 <bar><bar> empty(<SID>CtrlGU()) 
  \ ? '<S-Left>'
- \ : repeat('<C-G>U<Left>', col('.') - match(getline('.'), '\v\s\zs\w+\s?%' . col('.') . 'c') - 1)
-inoremap <expr> <S-Right> col('.') > match(getline('.'), '\s\w', col('.')-1)+1 <bar><bar> empty(<SID>CtrlGU())
+ \ : repeat('<C-G>U<Left>', col('.') - match(getline('.'), '\v\s\zs\S+\s?%' . col('.') . 'c') - 1)
+inoremap <expr> <S-Right> col('.') > match(getline('.'), '\s\S', col('.')-1)+1 <bar><bar> empty(<SID>CtrlGU())
  \ ? '<S-Right>'
- \ : repeat('<C-G>U<Right>', match(getline('.'), '\s\w', col('.')-1) - col('.') + 2)
+ \ : repeat('<C-G>U<Right>', match(getline('.'), '\s\S', col('.')-1) - col('.') + 2)
 
 if !has("gui_running")
   silent! exe "set <S-Left>=\<Esc>b"

--- a/plugin/rsi.vim
+++ b/plugin/rsi.vim
@@ -13,20 +13,38 @@ if &ttimeoutlen == -1
   set ttimeoutlen=50
 endif
 
-inoremap        <C-A> <C-O>^
+let g:keep_undo_sequence = v:version > 704 || v:version == 704 && has("patch849") ? 1 : 0
+
+inoremap <expr> <C-A> empty(g:keep_undo_sequence)
+\ ? "\<Lt>C-O>^"
+\ : col('.') >= match(getline('.'), '\S') + 1
+\   ? repeat('<C-G>U<Left>', col('.') - match(getline('.'), '\S') - 1)
+\   : repeat('<C-G>U<Right>', match(getline('.'), '\S') - col('.') + 1)
 inoremap   <C-X><C-A> <C-A>
 cnoremap        <C-A> <Home>
 cnoremap   <C-X><C-A> <C-A>
 
-inoremap <expr> <C-B> getline('.')=~'^\s*$'&&col('.')>strlen(getline('.'))?"0\<Lt>C-D>\<Lt>Esc>kJs":"\<Lt>C-g>U\<Lt>Left>"
+inoremap <expr> <C-B> getline('.')=~'^\s*$'&&col('.')>strlen(getline('.'))
+\ ? "0\<Lt>C-D>\<Lt>Esc>kJs"
+\ : g:keep_undo_sequence
+\   ? "\<Lt>C-G>U\<Lt>Left>"
+\   : "\<Lt>Left>"
 cnoremap        <C-B> <Left>
 
 inoremap <expr> <C-D> col('.')>strlen(getline('.'))?"\<Lt>C-D>":"\<Lt>Del>"
 cnoremap <expr> <C-D> getcmdpos()>strlen(getcmdline())?"\<Lt>C-D>":"\<Lt>Del>"
 
-inoremap <expr> <C-E> col('.')>strlen(getline('.'))<bar><bar>pumvisible()?"\<Lt>C-E>":"\<Lt>End>"
+inoremap <expr> <C-E> col('.')>strlen(getline('.'))<bar><bar>pumvisible()
+\ ? "\<Lt>C-E>"
+\ : empty(g:keep_undo_sequence)
+\   ? "\<Lt>End>"
+\   : repeat('<C-G>U<Right>', strlen(getline('.')) - col('.') + 1)
 
-inoremap <expr> <C-F> col('.')>strlen(getline('.'))?"\<Lt>C-F>":"\<Lt>C-g>U\<Lt>Right>"
+inoremap <expr> <C-F> col('.')>strlen(getline('.'))
+\ ? "\<Lt>C-F>"
+\ : g:keep_undo_sequence
+\   ? "\<Lt>C-G>U\<Lt>Right>"
+\   : "\<Lt>Right>"
 cnoremap <expr> <C-F> getcmdpos()>strlen(getcmdline())?&cedit:"\<Lt>Right>"
 
 if empty(mapcheck('<C-G>', 'c'))


### PR DESCRIPTION
Hello and thank you for your plugin,

currently, when you hit:
* `i` to go in insert mode
* `()`
* `<C-b>` to go one character backward
* `foo`
* `escape` to go back in normal mode

You end up with the text `(foo)`. However the last inserted text (the one in the dot register) is not `(foo)` but `foo`. I think it's because `<Left>` and `<Right>` breaks the undo sequence, it's discussed in `:help ins-special-special`.
If you prefix `<Left>` and `<Right>` with `<C-g>U`, then the whole edition is not broken anymore.

I don't know if you think it's a good idea, but on my machine it works and I prefer this behavior (because this way you can repeat your insertion with `.` even though you moved your cursor with `<C-b>` or `<C-f>`), so I made a simple modification to the code and propose you this pull request.

Thank you for reading my message.