### PR TITLE
Remove unrelated settings which should be set by users instead

### DIFF
--- a/plugin/rsi.vim
+++ b/plugin/rsi.vim
@@ -8,11 +8,6 @@ if exists("g:loaded_rsi") || v:version < 700 || &cp
 endif
 let g:loaded_rsi = 1
 
-set ttimeout
-if &ttimeoutlen == -1
-  set ttimeoutlen=50
-endif
-
 inoremap        <C-A> <C-O>^
 inoremap   <C-X><C-A> <C-A>
 cnoremap        <C-A> <Home>
@@ -39,10 +34,6 @@ cmap   <script> <C-T> <SID>transposition<SID>transpose
 
 if exists('g:rsi_no_meta')
   finish
-endif
-
-if &encoding ==# 'latin1' && has('gui_running') && !empty(findfile('plugin/sensible.vim', escape(&rtp, ' ')))
-  set encoding=utf-8
 endif
 
 noremap!        <M-b> <S-Left>


### PR DESCRIPTION
Hi Tim Pope,

I think vim-rsi should do its job as defined - add Readline key bindings only. Those unrelated settings should be done by users. If it does make senses, please accept it.

Thank you for your great works.