### PR TITLE
Skip META workaround for Neovim

### DIFF
--- a/plugin/rsi.vim
+++ b/plugin/rsi.vim
@@ -53,7 +53,7 @@ noremap!        <M-f> <S-Right>
 noremap!        <M-n> <Down>
 noremap!        <M-p> <Up>
 
-if !has("gui_running")
+if !has("gui_running") && !has('nvim')
   silent! exe "set <S-Left>=\<Esc>b"
   silent! exe "set <S-Right>=\<Esc>f"
   silent! exe "set <F31>=\<Esc>d"


### PR DESCRIPTION
NeoVim in the terminal works fine with meta maps (as well as \<ESC> map), I think we don't need those 'set' settings in NeoVim.