### PR TITLE
Dont hide <C-T>/<C-G> during incsearch for vim8

### DIFF
--- a/plugin/rsi.vim
+++ b/plugin/rsi.vim
@@ -30,12 +30,20 @@ inoremap <expr> <C-F> col('.')>strlen(getline('.'))?"\<Lt>C-F>":"\<Lt>Right>"
 cnoremap <expr> <C-F> getcmdpos()>strlen(getcmdline())?&cedit:"\<Lt>Right>"
 
 if empty(mapcheck('<C-G>', 'c'))
-  cmap <script> <C-G> <C-C>
+  if v:version > 704 || (v:version == 704 && has("patch2268"))
+    cmap <script><expr> <C-G> &incsearch && (getcmdtype() == "/" \|\| getcmdtype() == "?") ? "<C-G>" : "<C-C>"
+  else
+    cmap <script> <C-G> <C-C>
+  endif
 endif
 
 noremap! <expr> <SID>transposition getcmdpos()>strlen(getcmdline())?"\<Left>":getcmdpos()>1?'':"\<Right>"
 noremap! <expr> <SID>transpose "\<BS>\<Right>".matchstr(getcmdline()[0 : getcmdpos()-2], '.$')
-cmap   <script> <C-T> <SID>transposition<SID>transpose
+if v:version > 704 || (v:version == 704 && has("patch2268"))
+  cmap <script><expr> <C-T> &incsearch && (getcmdtype() == "/" \|\| getcmdtype() == "?") ? "<C-T>" : "<SID>transposition<SID>transpose"
+else
+  cmap <script> <C-T> <SID>transposition<SID>transpose
+endif
 
 if exists('g:rsi_no_meta')
   finish


### PR DESCRIPTION
Vim8 (or patch 7.4.2268) adds <C-T>/<C-G> to navigate between occurrences during incsearch.
This PR makes sure to keep these builtins available.