### PR TITLE
Allow disabling mappings in insert or cmdline mode

### DIFF
--- a/doc/rsi.txt
+++ b/doc/rsi.txt
@@ -71,6 +71,13 @@ To disable meta maps, add the following to your vimrc:
 >
     let g:rsi_no_meta = 1
 <
+
+By default mappings are registered for commandline and insert mode.
+To restrict it to only one mode use one of these settings:
+>
+    let g:rsi_disable_in_insert_mode  = 1
+    let g:rsi_disable_in_cmdline_mode = 1
+<
 ABOUT                                           *rsi-about*
 
 Grab the latest version or report a bug on GitHub:

--- a/plugin/rsi.vim
+++ b/plugin/rsi.vim
@@ -13,49 +13,57 @@ if &ttimeoutlen == -1
   set ttimeoutlen=50
 endif
 
-inoremap        <C-A> <C-O>^
-inoremap   <C-X><C-A> <C-A>
-cnoremap        <C-A> <Home>
-cnoremap   <C-X><C-A> <C-A>
+if !get(g:, 'rsi_disable_in_insert_mode')
+  inoremap        <C-A> <C-O>^
+  inoremap   <C-X><C-A> <C-A>
 
-inoremap <expr> <C-B> getline('.')=~'^\s*$'&&col('.')>strlen(getline('.'))?"0\<Lt>C-D>\<Lt>Esc>kJs":"\<Lt>Left>"
-cnoremap        <C-B> <Left>
+  inoremap <expr> <C-B> getline('.')=~'^\s*$'&&col('.')>strlen(getline('.'))?"0\<Lt>C-D>\<Lt>Esc>kJs":"\<Lt>Left>"
 
-inoremap <expr> <C-D> col('.')>strlen(getline('.'))?"\<Lt>C-D>":"\<Lt>Del>"
-cnoremap <expr> <C-D> getcmdpos()>strlen(getcmdline())?"\<Lt>C-D>":"\<Lt>Del>"
+  inoremap <expr> <C-D> col('.')>strlen(getline('.'))?"\<Lt>C-D>":"\<Lt>Del>"
 
-inoremap <expr> <C-E> col('.')>strlen(getline('.'))<bar><bar>pumvisible()?"\<Lt>C-E>":"\<Lt>End>"
+  inoremap <expr> <C-E> col('.')>strlen(getline('.'))<bar><bar>pumvisible()?"\<Lt>C-E>":"\<Lt>End>"
 
-inoremap <expr> <C-F> col('.')>strlen(getline('.'))?"\<Lt>C-F>":"\<Lt>Right>"
-cnoremap <expr> <C-F> getcmdpos()>strlen(getcmdline())?&cedit:"\<Lt>Right>"
+  inoremap <expr> <C-F> col('.')>strlen(getline('.'))?"\<Lt>C-F>":"\<Lt>Right>"
+endif
 
-function! s:transpose() abort
-  let pos = getcmdpos()
-  if getcmdtype() =~# '[?/]'
-    return "\<C-T>"
-  elseif pos > strlen(getcmdline())
-    let pre = "\<Left>"
-    let pos -= 1
-  elseif pos <= 1
-    let pre = "\<Right>"
-    let pos += 1
-  else
-    let pre = ""
-  endif
-  return pre . "\<BS>\<Right>".matchstr(getcmdline()[0 : pos-2], '.$')
-endfunction
+if !get(g:, 'rsi_disable_in_cmdline_mode')
+  cnoremap        <C-A> <Home>
+  cnoremap   <C-X><C-A> <C-A>
 
-cnoremap <expr> <C-T> <SID>transpose()
+  cnoremap        <C-B> <Left>
 
-function! s:ctrl_u()
-  if getcmdpos() > 1
-    let @- = getcmdline()[:getcmdpos()-2]
-  endif
-  return "\<C-U>"
-endfunction
+  cnoremap <expr> <C-D> getcmdpos()>strlen(getcmdline())?"\<Lt>C-D>":"\<Lt>Del>"
 
-cnoremap <expr> <C-U> <SID>ctrl_u()
-cnoremap        <C-Y> <C-R>-
+  cnoremap <expr> <C-F> getcmdpos()>strlen(getcmdline())?&cedit:"\<Lt>Right>"
+
+  function! s:transpose() abort
+    let pos = getcmdpos()
+    if getcmdtype() =~# '[?/]'
+      return "\<C-T>"
+    elseif pos > strlen(getcmdline())
+      let pre = "\<Left>"
+      let pos -= 1
+    elseif pos <= 1
+      let pre = "\<Right>"
+      let pos += 1
+    else
+      let pre = ""
+    endif
+    return pre . "\<BS>\<Right>".matchstr(getcmdline()[0 : pos-2], '.$')
+  endfunction
+
+  cnoremap <expr> <C-T> <SID>transpose()
+
+  function! s:ctrl_u()
+    if getcmdpos() > 1
+      let @- = getcmdline()[:getcmdpos()-2]
+    endif
+    return "\<C-U>"
+  endfunction
+
+  cnoremap <expr> <C-U> <SID>ctrl_u()
+  cnoremap        <C-Y> <C-R>-
+endif
 
 if exists('g:rsi_no_meta')
   finish
@@ -65,14 +73,25 @@ if &encoding ==# 'latin1' && has('gui_running') && !empty(findfile('plugin/sensi
   set encoding=utf-8
 endif
 
-noremap!        <M-b> <S-Left>
-noremap!        <M-d> <C-O>dw
-cnoremap        <M-d> <S-Right><C-W>
-noremap!        <M-f> <S-Right>
-noremap!        <M-n> <Down>
-noremap!        <M-p> <Up>
-noremap!        <M-BS> <C-W>
-noremap!        <M-C-h> <C-W>
+if !get(g:, 'rsi_disable_in_insert_mode')
+  inoremap        <M-b> <S-Left>
+  inoremap        <M-d> <C-O>dw
+  inoremap        <M-f> <S-Right>
+  inoremap        <M-n> <Down>
+  inoremap        <M-p> <Up>
+  inoremap        <M-BS> <C-W>
+  inoremap        <M-C-h> <C-W>
+endif
+
+if !get(g:, 'rsi_disable_in_cmdline_mode')
+  cnoremap        <M-b> <S-Left>
+  cnoremap        <M-d> <S-Right><C-W>
+  cnoremap        <M-f> <S-Right>
+  cnoremap        <M-n> <Down>
+  cnoremap        <M-p> <Up>
+  cnoremap        <M-BS> <C-W>
+  cnoremap        <M-C-h> <C-W>
+endif
 
 if !has("gui_running") && !has('nvim')
   silent! exe "set <M-b>=\eb"


### PR DESCRIPTION
Introduces the following new options:

- 'g:rsi_disable_in_insert_mode' to disable the mappings in insert mode.
- 'g:rsi_disable_in_cmdline_mode' to disable the mappings in cmdline mode.

The diff of this PR is way larger than I would like it to be (as it basically just wraps a few lines with a check for the above mentioned settings). But the alternative would have been to wrap nearly each line separately, which in my opinion would be even worse.

This PR fixes #39 and #41. It is very similar to #26, but extends to all mappings, not only the Meta mappings.

With this patch I am able to use `vim-rsi` for insert-mode and [readline.vim](https://github.com/ryvnf/readline.vim) for command line mode.