### PR TITLE
Allow accepting the current popup entry

### DIFF
--- a/plugin/rsi.vim
+++ b/plugin/rsi.vim
@@ -55,7 +55,7 @@ function! s:ctrl_u()
 endfunction
 
 cnoremap <expr> <C-U> <SID>ctrl_u()
-cnoremap        <C-Y> <C-R>-
+cnoremap <expr> <C-Y> pumvisible() ? "\<C-Y>" : "\<C-R>-"
 
 if exists('g:rsi_no_meta')
   finish


### PR DESCRIPTION
Make it possible to use the default mapping of `<c-y>` to select the current popup entry according to `:h complete_CTRL-Y`.